### PR TITLE
Remove legacy API usage from Snap! Inspector for forwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Sparkle Addons
 > [!WARNING]
-> Historically, Crackle addons were written to use a system in which each addon returned an object. Near the end of Crackle's development, this system was replaced but was never properly removed from the code.
-> 
-> Starting with Sparkle v0.3, such addons will no longer function properly. No new addons written this way will be accepted to the `SparkleAddons` repo.
+> Some of Sparkle's addon APIs have recently been deprecated and their usage is no longer allowed in SparkleAddons effective immediately. See Mojavesoft-Group/sparkle#39 for more information.
 
 
 Collection of Sparkle addons, downloaded/installed by the menu in Sparkle.

--- a/mods/snap-inspector.js
+++ b/mods/snap-inspector.js
@@ -79,7 +79,7 @@ return class extends Mod {
                             if (name in window.__crackle__.autoloadMods) {
                                 add(name);
                             }
-                            this.api.inform("In order to changes to take effect, you may have to refresh this page.", "Notice");
+                            this.ide.inform("In order to changes to take effect, you may have to refresh this page.", "Notice");
                         },
                         this,
                     ).promptCode("Edit addon code", window.__crackle__.modCodes[name], world);

--- a/mods/snap-inspector.js
+++ b/mods/snap-inspector.js
@@ -25,7 +25,7 @@ return class extends Mod {
     ID = "snap-inspector"; // the id of the addon
     NAME = "Snap! Inspector"; // human-readable name
     DESCRIPTION = "Inspect Snap!'s internals and temporarily patch them."; // description
-    VERSION = "1.0.1"; // version
+    VERSION = "1.1.0"; // version
     AUTHOR = "PPPDUD"; // author
     DEPENDS = []; // dependencies (addon ids, useful for libraries)
     DO_MENU = true; // whether to add a menu item


### PR DESCRIPTION
In Mojavesoft-Group/Sparkle#39 and Mojavesoft-Group/sparkle#40, many APIs previously found in Sparkle addons are being deprecated. This PR updates addons in the SparkleAddons repository to follow the new standards. This is a non-breaking change and shouldn't affect functionality for the end-user.